### PR TITLE
added dependency to console_bridge

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ rock_library(plugin_manager
             PluginLoader.hpp
             Exceptions.hpp
             Demangle.hpp
-    DEPS_PKGCONFIG class_loader tinyxml base-logging
+    DEPS_PKGCONFIG class_loader tinyxml base-logging console_bridge
     DEPS_CMAKE Glog 
     DEPS_PLAIN
         Boost_FILESYSTEM


### PR DESCRIPTION
I'm getting the following error in a rock installation:

```
[100%] Linking CXX executable test_suite
CMakeFiles/test_suite.dir/test_PluginLoader.cpp.o: In function `plugin_manager::BaseClass* class_loader::ClassLoader::createRawInstance<plugin_manager::BaseClass>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool)':
/media/wirkus/Data/development/modeling_buildconf/install/tools/class_loader/include/class_loader/class_loader.h:256: undefined reference to `console_bridge::log(char const*, int, console_bridge::LogLevel, char const*, ...)'
CMakeFiles/test_suite.dir/test_PluginLoader.cpp.o: In function `void class_loader::ClassLoader::onPluginDeletion<plugin_manager::BaseClass>(plugin_manager::BaseClass*)':
/media/wirkus/Data/development/modeling_buildconf/install/tools/class_loader/include/class_loader/class_loader.h:212: undefined reference to `console_bridge::log(char const*, int, console_bridge::LogLevel, char const*, ...)'
/media/wirkus/Data/development/modeling_buildconf/install/tools/class_loader/include/class_loader/class_loader.h:223: undefined reference to `console_bridge::log(char const*, int, console_bridge::LogLevel, char const*, ...)'
CMakeFiles/test_suite.dir/test_PluginLoader.cpp.o: In function `plugin_manager::BaseClass* class_loader::class_loader_private::createInstance<plugin_manager::BaseClass>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, class_loader::ClassLoader*)':
/media/wirkus/Data/development/modeling_buildconf/install/tools/class_loader/include/class_loader/class_loader_core.h:238: undefined reference to `console_bridge::log(char const*, int, console_bridge::LogLevel, char const*, ...)'
/media/wirkus/Data/development/modeling_buildconf/install/tools/class_loader/include/class_loader/class_loader_core.h:251: undefined reference to `console_bridge::log(char const*, int, console_bridge::LogLevel, char const*, ...)'
CMakeFiles/test_suite.dir/test_PluginLoader.cpp.o:/media/wirkus/Data/development/modeling_buildconf/install/tools/class_loader/include/class_loader/class_loader_core.h:269: more undefined references to `console_bridge::log(char const*, int, console_bridge::LogLevel, char const*, ...)' follow
collect2: error: ld returned 1 exit status
test/CMakeFiles/test_suite.dir/build.make:184: recipe for target 'test/test_suite' failed
make[2]: *** [test/test_suite] Error 1
CMakeFiles/Makefile2:207: recipe for target 'test/CMakeFiles/test_suite.dir/all' failed
make[1]: *** [test/CMakeFiles/test_suite.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2
wirkus@MWIRKUS-LAP-U:build[consol_bridge]$ 
```

adding the dependency as in the PR solves the problem, but actually plugin_manager is not directly depending on console_bridge. The dependency comes in via class_loader, which seems to miss stating the dependency correctly (at least in a rock installation).

Here's the .pc file for class_loader:
```
prefix=/media/wirkus/Data/development/modeling_buildconf/install/tools/class_loader
exec_prefix=/media/wirkus/Data/development/modeling_buildconf/install/tools/class_loader
libdir=${prefix}/lib
includedir=${prefix}/include

Name: class_loader
Description: 
Version: 
Requires: 
Libs: -L${libdir} -lclass_loader /usr/lib/x86_64-linux-gnu/libboost_thread.so;/usr/lib/x86_64-linux-gnu/libboost_system.so;/usr/lib/x86_64-linux-gnu/libboost_chrono.so;/usr/lib/x86_64-linux-gnu/libboost_date_time.so;/usr/lib/x86_64-linux-gnu/libboost_atomic.so;/usr/lib/x86_64-linux-gnu/libpthread.so;/media/wirkus/Data/development/modeling_buildconf/install/base/logging/lib/libbase-logging.so;/usr/lib/libPocoFoundation.so;dl
Cflags: -I${includedir} 
```
