### PR TITLE
Use DEPS instead of DEPS_PLAIN for Boost libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,9 @@ rock_library(plugin_manager
             Demangle.hpp
     DEPS_PKGCONFIG class_loader tinyxml base-logging
     DEPS_CMAKE Glog 
-    DEPS_PLAIN
-        Boost_FILESYSTEM
-	Boost_SYSTEM
-	Boost_THREAD
+    DEPS
+        Boost::filesystem
+        Boost::system
+        Boost::thread
 )
 


### PR DESCRIPTION
Related issue: https://github.com/rock-core/base-cmake/pull/41